### PR TITLE
[lifecycle] docstrings + ux update to work with torch.apply

### DIFF
--- a/src/sparsetensors/quantization/lifecycle/calibration.py
+++ b/src/sparsetensors/quantization/lifecycle/calibration.py
@@ -28,6 +28,14 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def set_module_for_calibration(module: Module):
+    """
+    marks a layer as ready for calibration which activates observers
+    to update scales and zero points on each forward pass
+
+    apply to full model with `model.apply(set_module_for_calibration)`
+
+    :param module: module to set for calibration
+    """
     if not getattr(module, "quantization_scheme", None):
         # no quantization scheme nothing to do
         return

--- a/src/sparsetensors/quantization/lifecycle/frozen.py
+++ b/src/sparsetensors/quantization/lifecycle/frozen.py
@@ -23,6 +23,13 @@ __all__ = [
 
 
 def freeze_module_quantization(module: Module):
+    """
+    deletes observers so static quantization is completed.
+
+    apply to full model with `model.apply(freeze_module_quantization)`
+
+    :param module: module to freeze quantization for
+    """
     if not getattr(module, "quantization_scheme", None):
         # no quantization scheme nothing to do
         return


### PR DESCRIPTION
docstrings and a ux update for the quantization lifecycle
cleans up usage a bit to make support for `torch.apply` with the lifecycle a first class citizen